### PR TITLE
Moves Handler._reset_db_connection() call to get_base_paths_blocking()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,9 @@ jobs:
         env:
           SECRETS_CONTEXT: ${{ toJson(secrets) }}
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Script
         
         run: .github/workflows/scripts/script.sh

--- a/CHANGES/9515.bugfix
+++ b/CHANGES/9515.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug where the `/pulp/content/` page would return a 500 error after the database connection
+was closed due to a network problem or a database restart.

--- a/pulpcore/content/handler.py
+++ b/pulpcore/content/handler.py
@@ -128,9 +128,9 @@ class Handler:
         Returns:
             :class:`aiohttp.web.HTTPOk`: The response back to the client.
         """
-        self._reset_db_connection()
 
         def get_base_paths_blocking():
+            self._reset_db_connection()
             if self.distribution_model is None:
                 base_paths = list(Distribution.objects.values_list("base_path", flat=True))
             else:

--- a/pulpcore/tests/functional/api/using_plugin/test_distributions.py
+++ b/pulpcore/tests/functional/api/using_plugin/test_distributions.py
@@ -1,6 +1,7 @@
 """Tests that perform actions over distributions."""
 import csv
 import hashlib
+from time import sleep
 import unittest
 from urllib.parse import urljoin
 
@@ -15,6 +16,7 @@ from pulp_smash.pulp3.utils import (
     get_versions,
     modify_repo,
     sync,
+    utils as pulp3_utils,
 )
 from requests.exceptions import HTTPError
 
@@ -411,6 +413,36 @@ class ContentServePublicationDistributionTestCase(unittest.TestCase):
             "1.iso",
             headers={"Range": "bytes=10485860-10485870"},
         )
+
+    def test_content_served_after_db_restart(self):
+        """
+        Assert that content can be downloaded after the database has been restarted.
+
+        This test also check that the HTML page with a list of distributions is also
+        available after the connection to the database has been closed.
+        """
+        cfg = config.get_config()
+        pulp_host = cfg.hosts[0]
+        svc_mgr = cli.ServiceManager(cfg, pulp_host)
+        if svc_mgr._svc_mgr == "s6":
+            postgresql_service_name = "postgresql"
+        else:
+            postgresql_service_name = "*postgresql*"
+        postgresql_found = svc_mgr.is_active([postgresql_service_name])
+        self.assertTrue(
+            postgresql_found, "PostgreSQL service not found or is not active. Can't restart it."
+        )
+        svc_mgr.restart([postgresql_service_name])
+        # Wait for postgres to come back and all services to recover
+        sleep(2)
+        self.setup_download_test("immediate")
+        self.do_test_content_served()
+        url_fragments = [
+            cfg.get_content_host_base_url(),
+            "pulp/content",
+        ]
+        content_app_root = "/".join(url_fragments)
+        pulp3_utils.http_get(content_app_root)
 
     def setup_download_test(self, policy, url=None, publish=True):
         # Create a repository


### PR DESCRIPTION
This change ensures that the connection is reset inside the same thread that is
used to perform ORM calls.

This fixes a bug where the /pulp/content/ page would return a 500 error after the
connection the database is closed due to a network problem or a database restart.

fixes: #9515
https://pulp.plan.io/issues/9515

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
