### PR TITLE
Set the correct value for Content-Length for Range requests

### DIFF
--- a/.github/workflows/scripts/before_install.sh
+++ b/.github/workflows/scripts/before_install.sh
@@ -106,7 +106,7 @@ if [ -n "$PULP_CLI_PR_NUMBER" ]; then
 fi
 
 cd pulp-cli
-pip install -e .
+pip install .
 pulp config create --base-url https://pulp --location tests/cli.toml 
 mkdir ~/.config/pulp
 cp tests/cli.toml ~/.config/pulp/cli.toml

--- a/CHANGES/3055.bugfix
+++ b/CHANGES/3055.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug where Content-Length header value was wrong when on-demand content was requested with
+a Range header that has an end value greater than the size of the content.


### PR DESCRIPTION
This patch fixes a bug that would occur when a client would submit a Range with
an end value that is greater than size of on-demand content.

fixes: #3055

Please be sure you have read our documentation on creating PRs:
https://docs.pulpproject.org/contributing/pull-request-walkthrough.html
